### PR TITLE
locking dev deps, deprecating a method and skipping a test for php 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,17 @@ language: php
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
+
 env:
   global:
-    - COMPOSER_ARGS="" TMPDIR=/tmp USE_XDEBUG=false
+    - COMPOSER_ARGS=""
+    - TMPDIR=/tmp
+    - USE_XDEBUG=false
+    - COMPOSER_DISCARD_CHANGES=1
 
 branches:
   only:
@@ -49,7 +57,7 @@ jobs:
       env: COMPOSER_ARGS="--ignore-platform-reqs --prefer-lowest"
     - php: nightly
       env: COMPOSER_ARGS="--ignore-platform-reqs"
-      
+
     - stage: style check
       php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=false

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     ],
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
-    "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
         "php": ">=7.0.0",
@@ -36,9 +35,9 @@
     ],
     "require-dev": {
         "phpunit/phpunit": "^7.0",
-        "phpstan/phpstan": "^0.11.2",
+        "phpstan/phpstan": "0.11.15",
         "jetbrains/phpstorm-stubs": "dev-phpstan",
-        "friendsofphp/php-cs-fixer": "^2.11",
+        "friendsofphp/php-cs-fixer": "2.15.2",
         "maglnet/composer-require-checker": "^1.1.0",
         "phpro/grumphp": "^0.14.0"
     },

--- a/src/Zend/Crypt/Math.php
+++ b/src/Zend/Crypt/Math.php
@@ -38,18 +38,28 @@ class Zend_Crypt_Math extends Zend_Crypt_Math_BigInteger
      * @param string|int $minimum
      * @param string|int $maximum
      * @return string|false|int
+     * @deprecated This method should not be used because it's broken and won't return a number in the range specified
      */
     public function rand($minimum, $maximum)
     {
+        // The result of this block will return a binary string, which isn't a number between
+        // minimum and maximum.
         if (file_exists('/dev/urandom')) {
             $frandom = fopen('/dev/urandom', 'r');
             if ($frandom !== false) {
                 return fread($frandom, strlen($maximum) - 1);
             }
         }
+        // This is the only case where this method actually returns a number between minimum
+        // and maximum
         if (strlen($maximum) < 4) {
             return mt_rand($minimum, $maximum - 1);
         }
+
+        // This will return a number that is the same length as the maximum input, but there's nothing
+        // to guarantee that the returned number is greater than the minimum, or less than the maximum
+        // since it's just generating a number of strlen($maximum) using random numbers for each position
+        // in the string.
         $rand = '';
         $i2   = strlen($maximum) - 1;
         for ($i = 1; $i < $i2; $i++) {

--- a/tests/Zend/Crypt/MathTest.php
+++ b/tests/Zend/Crypt/MathTest.php
@@ -33,6 +33,10 @@ class Zend_Crypt_MathTest extends PHPUnit\Framework\TestCase
 {
     public function testRand()
     {
+        // This test never really worked properly because it's doing a strict comparison on the result of
+        // bccomp, which returns an integer (and it's comparing to string values).
+        $this->markTestSkipped('This test is broken');
+
         if (!extension_loaded('bcmath')) {
             $this->markTestSkipped('Extension bcmath not loaded');
         }


### PR DESCRIPTION
The comments I've added describe the situation more (inline with the code), but essentially, this component was failing tests in PHP 7.4 because `bccomp` has changed a bit to throw a warning when the input parameters aren't valid (example of that here: https://3v4l.org/blFki).

In this case the `$result` parameter of that test was a binary string that came from reading the output of `/dev/urandom` (if available on the system, which it was on travis).  `$result` is supposed to be a random number between the `$lower` and `$higher` inputs.  You might notice that in that 3v4l.org link I pasted that even in php < 7.4 the result of the `bccomp` call was `-1`, which should cause one of these assertions to fail, but the assertions are checking that the result of `bccomp` `!== '-1'` or `!== '1'`. The return of `bccomp` is an `integer` not a `string`, so these checks will always be `true`.

I just marked this faulty method as `@deprecated` and then skipped the test since it's broken, rather than trying to fix any of this.  Functionality hasn't changed at all, but if something like phpstan or psalm are used, should get alerts if the deprecated method is being used in the code base.